### PR TITLE
Feature/filter by glob

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,1 @@
-/nix/store/ai26bfvzbb2dlb6vlqz7x6dmyqvqjyrl-pre-commit-config.json
+/nix/store/20lz83m06y32ya6vpx8ssa4z50fn82v5-pre-commit-config.json

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -38,15 +38,14 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1734797603,
-        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
+        "lastModified": 1741379162,
+        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
+        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
         "type": "github"
       },
       "original": {
@@ -91,39 +90,26 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,9 @@
             src = ./.;
             subPackages = ["tools/${name}"];
             # First try with vendorHash = null to get the correct hash
-            vendorHash = "sha256-WAOhkaM6KtN6SnkzQW30C4yOSRcbnrx1NDnmeVFewA8="; # update whenever go.mod changes
-            # vendorHash = ""; # update whenever go.mod changes. don't foget to `ga .`  🤡
+            # vendorHash = "sha256-WAOhkaM6KtN6SnkzQW30C4yOSRcbnrx1NDnmeVFewA8="; # update whenever go.mod changes
+            # vendorHash = "sha256-J4JgPrtLCXO+dcCNQIg+Il+9qzMbUcH3LWUy9U90+ns="; # update whenever go.mod changes. don't foget to `ga .`  🤡
+            vendorHash = "sha256-wy5DL75A12OGbirgYSOkU0xBQ8OL2Q9S908sT030MN0="; # update whenever go.mod changes. don't foget to `ga .`  🤡
           };
       in {
         # Packages

--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,7 @@
             src = ./.;
             subPackages = ["tools/${name}"];
             # First try with vendorHash = null to get the correct hash
-            # vendorHash = "sha256-WAOhkaM6KtN6SnkzQW30C4yOSRcbnrx1NDnmeVFewA8="; # update whenever go.mod changes
-            # vendorHash = "sha256-J4JgPrtLCXO+dcCNQIg+Il+9qzMbUcH3LWUy9U90+ns="; # update whenever go.mod changes. don't foget to `ga .`  🤡
+            # vendorHash = ""; # update whenever go.mod changes
             vendorHash = "sha256-wy5DL75A12OGbirgYSOkU0xBQ8OL2Q9S908sT030MN0="; # update whenever go.mod changes. don't foget to `ga .`  🤡
           };
       in {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.4
 
 require (
 	github.com/atotto/clipboard v0.1.4
+	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.2.4
 	github.com/charmbracelet/glamour v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=
+github.com/bmatcuk/doublestar/v4 v4.8.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=
 github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
 github.com/charmbracelet/bubbletea v1.2.4 h1:KN8aCViA0eps9SCOThb2/XPIlea3ANJLUkv3KnQRNCE=

--- a/justfile
+++ b/justfile
@@ -31,6 +31,10 @@ lint-all:
 clean:
     rm -rf result
 
+# Update flake.lock
+update:
+    nix flake update
+
 # Run pre-commit hooks
 pre-commit:
     nix develop --command bash -c 'pre-commit run --all-files'

--- a/tools/appender/find.go
+++ b/tools/appender/find.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	doublestar "github.com/bmatcuk/doublestar/v4"
+	"github.com/charmbracelet/bubbles/textarea"
+)
+
+func initFindInput() textarea.Model {
+	ti := textarea.New()
+	ti.Placeholder = "Enter glob pattern..."
+	ti.ShowLineNumbers = false
+	ti.SetHeight(1)
+	ti.CharLimit = 255
+	// Set initial value to empty string explicitly
+	ti.SetValue("")
+	return ti
+}
+
+// performFind executes a glob pattern search and stores matches.
+func (m *model) performFind() {
+	filters := make([]FilterFunc, 0)
+	if m.removeHidden {
+		filters = append(filters, FilterHidden)
+	}
+	filters = append(filters, FilterBinary)
+
+	pattern := m.findPattern.Value()
+	if pattern == "" {
+		m.matchedNodes = nil
+		m.currentMatchIdx = -1
+		return
+	}
+
+	// Ensure pattern is relative to workDir
+	searchPattern := filepath.Join(m.workDir, pattern)
+
+	matches, err := doublestar.FilepathGlob(searchPattern)
+	if err != nil {
+		slog.Error("Error in glob pattern", "pattern", searchPattern, "error", err)
+		m.matchedNodes = nil
+		m.currentMatchIdx = -1
+		return
+	}
+
+	slog.Info(
+		"Searching for pattern",
+		"pattern",
+		searchPattern,
+		"workDir",
+		m.workDir,
+		"matches",
+		matches,
+	)
+	// Store matching nodes
+	m.matchedNodes = make([]*FileNode, 0, len(matches))
+	for _, match := range matches {
+		if node, ok := m.nodeLookup[match]; ok {
+			if !include(node, filters...) {
+				continue
+			}
+
+			m.matchedNodes = append(m.matchedNodes, node)
+
+			// Ensure parent directories are expanded to show match
+			m.ensureNodeVisible(node)
+		}
+	}
+
+	// Reset current match index
+	if len(m.matchedNodes) > 0 {
+		m.currentMatchIdx = 0
+
+		// Navigate to first match
+		m.navigateToMatch(0)
+	} else {
+		m.currentMatchIdx = -1
+	}
+
+	// Refresh the tree view
+	m.flattenTree()
+}
+
+// ensureNodeVisible expands all parent directories of a node.
+func (m *model) ensureNodeVisible(node *FileNode) {
+	// Get the parent directory path
+	parentPath := filepath.Dir(node.path)
+
+	// If we're already at the root, no need to continue
+	if parentPath == m.workDir || parentPath == "." || parentPath == node.path {
+		return
+	}
+
+	// Find and expand the parent node
+	if parentNode, ok := m.nodeLookup[parentPath]; ok {
+		parentNode.expanded = true
+
+		// Recursively ensure parent's parent is expanded
+		m.ensureNodeVisible(parentNode)
+	}
+}
+
+// navigateToMatch moves the cursor to the specified match index.
+func (m *model) navigateToMatch(idx int) {
+	if idx < 0 || idx >= len(m.matchedNodes) {
+		return
+	}
+
+	// Update current match index
+	m.currentMatchIdx = idx
+
+	// Find the flat index of the matched node
+	matchedNode := m.matchedNodes[idx]
+	for i, node := range m.flatNodes {
+		if node.path == matchedNode.path {
+			// Set cursor to this node
+			m.cursor = i
+
+			// Ensure the node is visible in viewport
+			m.ensureNodeInViewport()
+			break
+		}
+	}
+}
+
+// ensureNodeInViewport adjusts the offset to make sure the current cursor is visible.
+func (m *model) ensureNodeInViewport() {
+	helpLines := len(strings.Split(helpMsg, "\n"))
+	maxVisibleNodes := m.windowSize.height - helpLines - 2
+
+	// If cursor is below the viewport, adjust offset
+	if m.cursor >= m.offset+maxVisibleNodes {
+		m.offset = m.cursor - maxVisibleNodes + 1
+	}
+
+	// If cursor is above the viewport, adjust offset
+	if m.cursor < m.offset {
+		m.offset = m.cursor
+	}
+}
+
+// nextMatch navigates to the next match.
+func (m *model) nextMatch() {
+	if len(m.matchedNodes) == 0 {
+		return
+	}
+
+	nextIdx := (m.currentMatchIdx + 1) % len(m.matchedNodes)
+	m.navigateToMatch(nextIdx)
+}
+
+// prevMatch navigates to the previous match.
+func (m *model) prevMatch() {
+	if len(m.matchedNodes) == 0 {
+		return
+	}
+
+	prevIdx := m.currentMatchIdx - 1
+	if prevIdx < 0 {
+		prevIdx = len(m.matchedNodes) - 1
+	}
+	m.navigateToMatch(prevIdx)
+}

--- a/tools/appender/help.go
+++ b/tools/appender/help.go
@@ -12,16 +12,20 @@ type keyMap struct {
 	Copy       key.Binding
 	Help       key.Binding
 	Quit       key.Binding
+	Find       key.Binding
+	NextMatch  key.Binding
+	PrevMatch  key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Help, k.Quit}
+	return []key.Binding{k.Find, k.Help, k.Quit}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.ToggleDir},
 		{k.Select, k.ToggleHide, k.Save},
+		{k.Find, k.NextMatch, k.PrevMatch},
 		{k.Copy, k.Help, k.Quit},
 	}
 }
@@ -62,5 +66,17 @@ var keys = keyMap{
 	Quit: key.NewBinding(
 		key.WithKeys("q", "ctrl+c"),
 		key.WithHelp("q", "quit"),
+	),
+	Find: key.NewBinding(
+		key.WithKeys("/"),
+		key.WithHelp("/", "find"),
+	),
+	NextMatch: key.NewBinding(
+		key.WithKeys("n"),
+		key.WithHelp("n", "next match"),
+	),
+	PrevMatch: key.NewBinding(
+		key.WithKeys("N"),
+		key.WithHelp("N", "prev match"),
 	),
 }


### PR DESCRIPTION
## Search Functionality

The search feature uses glob patterns to find files and directories in your workspace:

- Type `/` to enter search mode
- Enter a glob pattern (e.g., `*.go`, `**/*.md`)
- Press `Enter` to execute the search
- Use `n` and `N` to navigate between matches
- Press `Esc` to clear search results

Glob patterns support:
- `*`: Matches any sequence of characters in a filename
- `**`: Matches any sequence of directories 
- `?`: Matches any single character
- `[abc]`: Matches any of the characters in brackets
- `[!abc]`: Matches any character not in brackets

Examples:
- `*.go`: All Go files in the current directory
- `**/*.go`: All Go files in any subdirectory
- `cmd/*/main.go`: All main.go files one level under the cmd directory
- `[a-c]*/`: All directories starting with a, b, or c

The search respects your hidden files setting, so `.git` directories will be excluded when hidden files are toggled off.
